### PR TITLE
Fix example script cleanup directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ echo 'Deploying'
 firebase deploy --force --only functions
 
 echo 'Cleaning up ./out folder'
-rm -Rf ./out
+rm -Rf ../out
 ```
 
 ### More examples soon:


### PR DESCRIPTION
Hey there,

I realized that the clean up step of the example script is not deleting the out directory, which I believe is because script executes `cd ./out` a few steps back and then tries to `rm -Rf ./out` when it's actually in `./out`

I'm proposing to delete `../out` instead of `./out` since the script at that point is already in the out directory.

(I'm on macOS)